### PR TITLE
fix: use `isolate_path` fixture, not `work_path`.

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -56,7 +56,7 @@ def isolate_index_path(isolate_path: Path):
 
 
 @fixture
-def isolate_vta_path(work_path: Path):
+def isolate_vta_path(isolate_path: Path):
     return isolate_path / "to_isolates.vta"
 
 


### PR DESCRIPTION
The `isolate_path` fixture was not used, so the function `isolate_path` was used instead leading to a TypeError.