### PR TITLE
fix: stop logging stdout for bowtie

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -16,8 +16,6 @@ from virtool_workflow.data_model.samples import Sample
 from workflow import (map_default_isolates, map_isolates, map_subtractions,
                       reassignment, subtract_mapping)
 
-logger = logging.getLogger(__name__)
-
 TEST_DATA_PATH = Path(__file__).parent / "test_files"
 FASTQ_PATH = TEST_DATA_PATH / "test.fq"
 INDEX_PATH = TEST_DATA_PATH / "index"
@@ -172,8 +170,7 @@ async def test_map_default_isolates(data_regression, read_file_names, index: Ind
         index,
         2,
         0.01,
-        run_subprocess,
-        logger
+        run_subprocess
     )
 
     assert sorted(intermediate.to_otus) == sorted([
@@ -206,7 +203,6 @@ async def test_map_isolates(
 ):
     for path in INDEX_PATH.iterdir():
         if "reference" in path.name:
-            logger.info(path)
             shutil.copyfile(
                 path,
                 work_path / path.name.replace("reference", "isolates")

--- a/workflow.py
+++ b/workflow.py
@@ -93,8 +93,7 @@ async def map_default_isolates(
         index: Index,
         proc: int,
         p_score_cutoff: float,
-        run_subprocess: RunSubprocess,
-        logger,
+        run_subprocess: RunSubprocess
 ):
     """
     Map reads to the main OTU reference.
@@ -103,8 +102,6 @@ async def map_default_isolates(
 
     """
     async def stdout_handler(line: bytes):
-        logger.debug(line)
-
         line = line.decode()
 
         if line[0] == "#" or line[0] == "@":


### PR DESCRIPTION
This pushes a ton of data to K8S in production. Remove `logger.debug` call in Bowtie output handler.

Since the standard output of Bowtie2 is SAM formatted alignments, it is unlikely to be useful for workflow debugging.