### PR TITLE
fix: resolve error during isolate index build

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -140,6 +140,7 @@ async def map_default_isolates(
 
 @step
 async def build_isolate_index(
+        index: Index,
         isolate_fasta_path: Path,
         isolate_index_path: Path,
         run_subprocess: RunSubprocess,


### PR DESCRIPTION
Due to `index` fixture not being passed into step function.