### PR TITLE
feat: support exiting after one job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM virtool/workflow:2.0.0 as base
+FROM virtool/workflow:2.1.0 as base
 WORKDIR /app
 COPY workflow.py .
 COPY pathoscope.py .

--- a/poetry.lock
+++ b/poetry.lock
@@ -438,7 +438,7 @@ pydantic = ">=1.8.2,<2.0.0"
 
 [[package]]
 name = "virtool-workflow"
-version = "2.0.0"
+version = "2.1.0"
 description = "A framework for developing bioinformatics workflows for Virtool."
 category = "main"
 optional = false
@@ -954,8 +954,8 @@ virtool-core = [
     {file = "virtool_core-0.4.0-py3-none-any.whl", hash = "sha256:3fd38d8d97c86ded02c1a9d3cfe770d459195084caba0223c6f247bbe8acafcc"},
 ]
 virtool-workflow = [
-    {file = "virtool-workflow-2.0.0.tar.gz", hash = "sha256:f05582bca8fc5e5a0b8caf467980a047d9fbaa6b5a51545b3fdf9698801e3ec4"},
-    {file = "virtool_workflow-2.0.0-py3-none-any.whl", hash = "sha256:a4617cd7932856c420bd6348a63b62f4fbcad324c3e29e15d9f82df157058933"},
+    {file = "virtool-workflow-2.1.0.tar.gz", hash = "sha256:94c17e00ce3ae831f74f253b0fba924d428213f19bdf3bbd53218b65f5b056e7"},
+    {file = "virtool_workflow-2.1.0-py3-none-any.whl", hash = "sha256:4b85f8e2ec4b7d90cb19fb0b6ceed4a5ce2e8b23af17c88f3a6e4117b54ab121"},
 ]
 wasmer = [
     {file = "wasmer-1.1.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:c2af4b907ae2dabcac41e316e811d5937c93adf1f8b05c5d49427f8ce0f37630"},


### PR DESCRIPTION
Requires upgrade to `virtool-workflow==2.1.0`.