### PR TITLE
Use  `virtool-workflow==5.4.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:buster as prep
 WORKDIR /build
 RUN apt-get update && apt-get install -y make gcc zlib1g-dev wget unzip
-RUN wget https://zlib.net/pigz/pigz-2.7.tar.gz && \
-    tar -xzvf pigz-2.7.tar.gz && \
-    cd pigz-2.7 && \
+RUN wget https://zlib.net/pigz/pigz-2.8.tar.gz && \
+    tar -xzvf pigz-2.8.tar.gz && \
+    cd pigz-2.8 && \
     make
 RUN wget https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.9.zip && \
     unzip fastqc_v0.11.9.zip
@@ -16,7 +16,7 @@ FROM python:3.10-buster as base
 WORKDIR /app
 COPY --from=prep /build/bowtie2/* /usr/local/bin/
 COPY --from=prep /build/FastQC /opt/fastqc
-COPY --from=prep /build/pigz-2.7/pigz /usr/local/bin/pigz
+COPY --from=prep /build/pigz-2.8/pigz /usr/local/bin/pigz
 RUN chmod ugo+x /opt/fastqc/fastqc && \
     ln -fs /opt/fastqc/fastqc /usr/local/bin/fastqc && \
     for file in `ls /opt/hmmer/bin`; do ln -fs /opt/hmmer/bin/${file} /usr/local/bin/${file};  done

--- a/poetry.lock
+++ b/poetry.lock
@@ -1865,13 +1865,13 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtool-core"
-version = "4.13.0"
+version = "5.0.0"
 description = "Core utilities for Virtool."
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "virtool_core-4.13.0-py3-none-any.whl", hash = "sha256:41039ae3b74b9cdf5422d0d537c049a7731a70c13a98398de8e4c9789518b8fe"},
-    {file = "virtool_core-4.13.0.tar.gz", hash = "sha256:9d57d93884fc54c6f43efe0439bde720e9fdc91a692cd470b5a5cbfb3975acff"},
+    {file = "virtool_core-5.0.0-py3-none-any.whl", hash = "sha256:a71902fd73fb6c5b33884de0cf30e6296166b3a9c08130f8344de89b74225c90"},
+    {file = "virtool_core-5.0.0.tar.gz", hash = "sha256:feea62698982bebf08fdceceb4ccb2c0d7c4b32da230e1874a8bbca96a9992ce"},
 ]
 
 [package.dependencies]
@@ -1888,13 +1888,13 @@ pydantic = ">=1.8.2,<2.0.0"
 
 [[package]]
 name = "virtool-workflow"
-version = "5.3.2"
+version = "5.4.0"
 description = "A framework for developing bioinformatics workflows for Virtool."
 optional = false
 python-versions = ">=3.10,<4.0"
 files = [
-    {file = "virtool_workflow-5.3.2-py3-none-any.whl", hash = "sha256:cd53f8e137aad06a4472f2cae67e124fc0ef0b0a6e873006c8f00f081d4c30ca"},
-    {file = "virtool_workflow-5.3.2.tar.gz", hash = "sha256:85a4fd6da4b49e14fd538d9992e34fbecdbf01b4442e0dd726b3d14f7ad16bb3"},
+    {file = "virtool_workflow-5.4.0-py3-none-any.whl", hash = "sha256:e12136ddbcb1c5d9f9c977ad542ad37ce32d710715ca89a4e28cc6c51eb0fc5d"},
+    {file = "virtool_workflow-5.4.0.tar.gz", hash = "sha256:f55ce30b59843398e485d536942c258e8fa05a61f964e8363c9fb37852e3073d"},
 ]
 
 [package.dependencies]
@@ -1904,7 +1904,7 @@ aioredis = "1.3.1"
 click = ">=8.0.0,<9.0.0"
 pyfixtures = ">=1.0.0,<2.0.0"
 sentry-sdk = ">=1.5.7,<2.0.0"
-virtool-core = ">=4.13.0,<5.0.0"
+virtool-core = ">=5.0.0,<6.0.0"
 
 [[package]]
 name = "virtualenv"


### PR DESCRIPTION
The upcoming server version `22.0.0` will not include the `caches` field in samples.
The `virtool-workflow` version used in this PR uses the sample model with `caches` removed.