### PR TITLE
perf: optimize isolate mapping with bam format and improved tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.12.3-bookworm AS deps
 WORKDIR /app
-COPY --from=ghcr.io/virtool/tools:1.0.0 /tools/bowtie2/2.5.4/bowtie* /usr/local/bin/
-COPY --from=ghcr.io/virtool/tools:1.0.0 /tools/hmmer/3.2.1 /opt/hmmer
-COPY --from=ghcr.io/virtool/tools:1.0.0 /tools/fastqc/0.11.9 /opt/fastqc
-COPY --from=ghcr.io/virtool/tools:1.0.0 /tools/pigz/2.8/pigz /usr/local/bin/
+COPY --from=ghcr.io/virtool/tools:1.1.0 /tools/bowtie2/2.5.4/bowtie* /usr/local/bin/
+COPY --from=ghcr.io/virtool/tools:1.1.0 /tools/hmmer/3.2.1 /opt/hmmer
+COPY --from=ghcr.io/virtool/tools:1.1.0 /tools/fastqc/0.11.9 /opt/fastqc
+COPY --from=ghcr.io/virtool/tools:1.1.0 /tools/pigz/2.8/pigz /usr/local/bin/
+COPY --from=ghcr.io/virtool/tools:1.1.0 /tools/samtools/1.22.1/bin/samtools /usr/local/bin/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends default-jre && \
     rm -rf /var/lib/apt/lists/* && \

--- a/fixtures.py
+++ b/fixtures.py
@@ -37,8 +37,8 @@ def isolate_index_path(isolate_path: Path):
 
 
 @fixture
-def isolate_sam_path(isolate_path: Path):
-    return isolate_path / "to_isolates.sam"
+def isolate_bam_path(isolate_path: Path):
+    return isolate_path / "to_isolates.bam"
 
 
 @fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ authors = [
 [dependency-groups]
 dev = [
     "maturin>=1.9.2",
+    "pysam>=0.22.0",
     "pytest>=7.4.2,<8.0.0",
     "pytest-asyncio<=0.23.8,<1.0.0",
     "pytest-mock<=3.14,<4.0.0",

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -153,6 +153,8 @@ async def test_map_isolates(
     snapshot: SnapshotAssertion,
     work_path: Path,
 ):
+    import pysam
+
     for path in (example_path / "index").iterdir():
         if "reference" in path.name:
             shutil.copyfile(
@@ -164,7 +166,7 @@ async def test_map_isolates(
 
     isolate_fastq_path = work_path / "mapped.fq"
     isolate_index_path = work_path / "isolates"
-    isolate_sam_path = work_path / "to_isolates.sam"
+    isolate_bam_path = work_path / "to_isolates.bam"
 
     proc = 1
     p_score = 0.01
@@ -173,18 +175,21 @@ async def test_map_isolates(
         intermediate,
         isolate_fastq_path,
         isolate_index_path,
-        isolate_sam_path,
+        isolate_bam_path,
         proc,
         p_score,
         run_subprocess,
         sample,
     )
 
-    with isolate_sam_path.open("r") as f:
-        assert (
-            sorted(line.rstrip() for line in f if not line.startswith("@PG"))
-            == snapshot
-        )
+    # Convert BAM to text for snapshot comparison
+    with pysam.AlignmentFile(isolate_bam_path, "rb") as bam:
+        lines = []
+        for read in bam:
+            # Convert each record to SAM format text (excluding header)
+            lines.append(read.to_string())
+        
+        assert sorted(lines) == snapshot
 
     # Note: isolate_high_scores is now populated during eliminate_subtraction step
     # The test just verifies that the SAM file is written correctly
@@ -204,12 +209,15 @@ async def test_eliminate_subtraction(
     work_path: Path,
 ):
     isolate_fastq_path = work_path / "to_isolates.fq"
-    isolate_sam_path = work_path / "to_isolates.sam"
+    isolate_bam_path = work_path / "to_isolates.bam"
     subtracted_path = work_path / "subtracted.sam"
 
     logger = get_logger("test")
 
-    shutil.copyfile(example_path / "to_isolates.sam", isolate_sam_path)
+    # Convert example SAM to BAM for this test
+    await run_subprocess([
+        "samtools", "view", "-bS", "-o", str(isolate_bam_path), str(example_path / "to_isolates.sam")
+    ])
     shutil.copyfile(example_path / "to_isolates.fq", isolate_fastq_path)
 
     proc = 2
@@ -224,7 +232,7 @@ async def test_eliminate_subtraction(
     await eliminate_subtraction(
         intermediate,
         isolate_fastq_path,
-        isolate_sam_path,
+        isolate_bam_path,
         logger,
         0.01,  # p_score_cutoff
         proc,
@@ -245,7 +253,17 @@ async def test_eliminate_subtraction(
     with open(work_path / "subtracted.sam") as f:
         for line in f:
             split = line.split("\t")
-            lines[split[0]] = split[1:]
+            # Filter out @PG lines that contain variable paths
+            if split[0].startswith("@PG") and len(split) > 1:
+                filtered_parts = []
+                for part in split[1:]:
+                    # Skip the CL (command line) field that contains variable paths
+                    if part.startswith("CL:"):
+                        continue
+                    filtered_parts.append(part)
+                lines[split[0]] = filtered_parts
+            else:
+                lines[split[0]] = split[1:]
 
     assert lines == snapshot
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12.3, <3.13"
 
 [[package]]
@@ -757,6 +757,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pysam"
+version = "0.23.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2b/1cf19890a0e4c73ad2672ce7eb485606c4bd2846eef2d892c078ab193c92/pysam-0.23.3.tar.gz", hash = "sha256:9ebcb1f004b296fd139b103ec6fd7e415e80f89f194eb7d0d972ac6d11bbaf24", size = 4974405, upload-time = "2025-06-10T11:19:54.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/6b/dd9f94da44463ecfddb7075f1048c044155c725d7d79fde2e7957561a3b0/pysam-0.23.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:69f90c0867fe43f04004bcea963f6b2e68b39180afab54bf551f61f43856638b", size = 6177042, upload-time = "2025-06-10T11:19:19.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e9/686e711a559a02e4c3ba0bc78cf031d9ddb525e9f0b2984d1b66536ba94a/pysam-0.23.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2310d72bfae7a0980d414156267e25b57aa221a768c11c087f3f7d00ceb9fed4", size = 8398187, upload-time = "2025-06-10T11:22:52.284Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/82/fca396e13969d1020956b02e567e0d357be0af0f3aebc2b4d97bed780a6d/pysam-0.23.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b2e45983efea190d374fcda0b6e0c835d6e9e474e02694729f3b3a14d680fa62", size = 23343831, upload-time = "2025-06-10T11:22:54.594Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a6/c100df6c8118b4ce1f9c086bb9cf5bccd4f71d05ceb2ecf474f3b0ea87b8/pysam-0.23.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4099393fc5097b5081c7efaf46b0109e4f0a8ed18f86d497219a8bf739c73992", size = 24021198, upload-time = "2025-06-10T11:19:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/92/32e1b13f30f16fe2c948f9b9e04c6e7698beaa539ea1a2bcddc51ed6c9b7/pysam-0.23.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4f04b9aa9b23d767fe36652eacb8370791e3b56816a7e50553d52c65ccdce77f", size = 22925815, upload-time = "2025-06-10T11:22:56.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7d/ccfaa2d6f9f07b357696b07883d5c5471f980938c2293324631425d95523/pysam-0.23.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:701843e5dc67c8eb217c3265039c699a5f83cce64fbc4225268141796e972353", size = 23351352, upload-time = "2025-06-10T11:19:24.207Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1089,6 +1103,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "maturin" },
+    { name = "pysam" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -1102,6 +1117,7 @@ requires-dist = [{ name = "virtool-workflow", specifier = "==7.2.2" }]
 [package.metadata.requires-dev]
 dev = [
     { name = "maturin", specifier = ">=1.9.2" },
+    { name = "pysam", specifier = ">=0.22.0" },
     { name = "pytest", specifier = ">=7.4.2,<8.0.0" },
     { name = "pytest-asyncio", specifier = "<=0.23.8,<1.0.0" },
     { name = "pytest-mock", specifier = "<=3.14,<4.0.0" },

--- a/workflow.py
+++ b/workflow.py
@@ -151,7 +151,7 @@ async def map_isolates(
     intermediate: SimpleNamespace,
     isolate_fastq_path: Path,
     isolate_index_path: Path,
-    isolate_sam_path: Path,
+    isolate_bam_path: Path,
     proc: int,
     p_score_cutoff: float,
     run_subprocess: RunSubprocess,
@@ -159,27 +159,9 @@ async def map_isolates(
 ):
     """Map sample reads to the all isolate index."""
     command = [
-        "bowtie2",
-        "-p",
-        str(proc),
-        "--no-unal",
-        "--local",
-        "--score-min",
-        "L,20,1.0",
-        "-N",
-        "0",
-        "-L",
-        "15",
-        "-k",
-        "100",
-        "--al",
-        isolate_fastq_path,
-        "-x",
-        isolate_index_path,
-        "-U",
-        ",".join(str(path) for path in sample.read_paths),
-        "-S",
-        isolate_sam_path,
+        "bash",
+        "-c",
+        f"bowtie2 -p {proc} --no-unal --local --score-min L,20,1.0 -N 0 -L 15 -k 100 --al {isolate_fastq_path} -x {isolate_index_path} -U {','.join(str(path) for path in sample.read_paths)} | samtools view -bS - -o {isolate_bam_path}"
     ]
 
     await run_subprocess(command)
@@ -189,7 +171,7 @@ async def map_isolates(
 async def eliminate_subtraction(
     intermediate: SimpleNamespace,
     isolate_fastq_path: Path,
-    isolate_sam_path: Path,
+    isolate_bam_path: Path,
     logger,
     p_score_cutoff: float,
     proc: int,
@@ -204,12 +186,12 @@ async def eliminate_subtraction(
     The input to this step is the reads that aligned to an isolate at least once in the
     previous step. We will align these against a subtraction (plant) genome. If the
     alignment score is higher against the subtraction, we drop alignments involving the
-    read from the SAM from the previous step and write the reduced one to
+    read from the BAM from the previous step and write the reduced one to
     `subtracted_sam_path`.
 
     :param intermediate: intermediate data storage for the workflow
     :param isolate_fastq_path: path to the FASTQ file containing reads that aligned to the isolates
-    :param isolate_sam_path: path to the SAM file of alignments to the isolates
+    :param isolate_bam_path: path to the BAM file of alignments to the isolates
     :param logger: workflow logger
     :param p_score_cutoff: minimum p_score cutoff for alignments
     :param proc: number of processors to use
@@ -219,18 +201,21 @@ async def eliminate_subtraction(
     :param subtracted_sam_path: path to the SAM file with subtraction-mapped reads removed
     :param work_path: path to the workflow working directory
     """
-    # Parse isolate scores from the SAM file
-    logger.info("Parsing isolate scores from SAM file")
+    # Parse isolate scores from the BAM file
+    logger.info("Parsing isolate scores from BAM file")
     intermediate.isolate_high_scores = await asyncio.to_thread(
         parse_isolate_scores,
-        str(isolate_sam_path),
+        str(isolate_bam_path),
         p_score_cutoff,
     )
     logger.info("Found isolate scores", count=len(intermediate.isolate_high_scores))
 
     if len(subtractions) == 0:
         logger.info("No subtractions to eliminate reads against. Skipping step.")
-        await asyncio.to_thread(shutil.copyfile, isolate_sam_path, subtracted_sam_path)
+        # Convert BAM to SAM since downstream expects SAM
+        await run_subprocess([
+            "samtools", "view", "-h", "-o", str(subtracted_sam_path), str(isolate_bam_path)
+        ])
         results["subtracted_count"] = 0
         return
 
@@ -241,9 +226,9 @@ async def eliminate_subtraction(
     # as to not disrupt possible uses elsewhere
     await asyncio.to_thread(shutil.copyfile, isolate_fastq_path, current_fastq_path)
 
-    # The SAM file that reads should be subtracted from if they map better to a
-    # subtraction.
-    current_sam_input_path = isolate_sam_path
+    # The file that reads should be subtracted from if they map better to a
+    # subtraction. Start with BAM, then use working SAM for subsequent iterations.
+    current_sam_input_path = isolate_bam_path
 
     subtracted_count = 0
 


### PR DESCRIPTION
- Switch from SAM to BAM format for compressed file handling
- Update virtool/tools container from 1.0.0 to 1.1.0
- Add samtools 1.22.1 for efficient BAM processing
- Enhance isolate mapping performance through binary format usage
