### PR TITLE
feat: upgrade virtool to 36.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ features = ["pyo3/extension-module"]
 asyncio_mode = "auto"
 
 [tool.uv.sources]
-virtool = { git = "https://github.com/virtool/virtool", tag = "36.17.0" }
+virtool = { git = "https://github.com/virtool/virtool", tag = "36.19.1" }
 
 [build-system]
 requires = ["maturin>=1.13.1,<2.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1178,7 +1178,7 @@ wheels = [
 [[package]]
 name = "virtool"
 version = "0.0.0"
-source = { git = "https://github.com/virtool/virtool?tag=36.17.0#50f2fa858970f4a398d0c9caf096bf9324894025" }
+source = { git = "https://github.com/virtool/virtool?tag=36.19.1#5e8cee133d854b40e20470eee6c5a666755d2f19" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp", extra = ["speedups"] },
@@ -1243,7 +1243,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=36.17.0" }]
+requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=36.19.1" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Upgrades the `virtool` dependency from tag `36.17.0` to `36.19.1`
- Updates `pyproject.toml` and `uv.lock` to reflect the new tag and commit hash

## Test plan
- [ ] Verify CI passes with the updated virtool version
- [ ] Confirm the workflow runs correctly end-to-end with virtool 36.19.1