### PR TITLE
Upgrade virtool to 36.20.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ features = ["pyo3/extension-module"]
 asyncio_mode = "auto"
 
 [tool.uv.sources]
-virtool = { git = "https://github.com/virtool/virtool", tag = "36.19.1" }
+virtool = { git = "https://github.com/virtool/virtool", tag = "36.20.1" }
 
 [build-system]
 requires = ["maturin>=1.13.1,<2.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1178,7 +1178,7 @@ wheels = [
 [[package]]
 name = "virtool"
 version = "0.0.0"
-source = { git = "https://github.com/virtool/virtool?tag=36.19.1#5e8cee133d854b40e20470eee6c5a666755d2f19" }
+source = { git = "https://github.com/virtool/virtool?tag=36.20.1#9eae8efe5d109b221a23691c095fe193bb46e1fa" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp", extra = ["speedups"] },
@@ -1243,7 +1243,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=36.19.1" }]
+requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=36.20.1" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Upgrades the `virtool` dependency from tag `36.19.1` to `36.20.1`
- Updates `uv.lock` to reflect the new commit hash for the upstream virtool repository

## Test plan
- [ ] Verify CI passes with the updated virtool version
- [ ] Confirm the workflow produces correct pathoscope results with virtool 36.20.1