### PR TITLE
feat(deps): update Virtool to 41.15.0

### DIFF
--- a/fixtures.py
+++ b/fixtures.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from pyfixtures import fixture
-from virtool.indexes.constants import INDEX_SQLITE_FILE_NAME
+from virtool.workflow.data.indexes import INDEX_SQLITE_FILE_NAME
 
 
 def get_reference_index_path(work_path: Path) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ features = ["pyo3/extension-module"]
 asyncio_mode = "auto"
 
 [tool.uv.sources]
-virtool = { git = "https://github.com/virtool/virtool", tag = "41.10.0" }
+virtool = { git = "https://github.com/virtool/virtool", tag = "41.15.0" }
 
 [build-system]
 requires = ["maturin>=1.14.1,<2.0"]

--- a/python/workflow_pathoscope/reference.py
+++ b/python/workflow_pathoscope/reference.py
@@ -347,7 +347,11 @@ async def collapse_reference_index(
     except ValueError:
         reference = None
 
-    await WFIndex.create(index.id, target_path, reference, collapsed_otus)
+    async def iter_collapsed_otus():
+        for otu in collapsed_otus:
+            yield otu
+
+    await WFIndex.create(index.id, target_path, reference, iter_collapsed_otus())
 
     return {
         "isolate_count_before": before_count,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -216,6 +216,15 @@ def assert_cache_params(
     assert TOOL_VERSION_PATTERN.fullmatch(params["tool_version"])
 
 
+async def as_async_iterable(items):
+    for item in items:
+        yield item
+
+
+async def create_wf_index(id_, path, reference, otus):
+    return await WFIndex.create(id_, path, reference, as_async_iterable(otus))
+
+
 async def create_test_index(path: Path) -> WFIndex:
     def sequence(id_: str, value: str) -> dict:
         return {
@@ -236,7 +245,7 @@ async def create_test_index(path: Path) -> WFIndex:
             "source_type": "isolate",
         }
 
-    return await WFIndex.create(
+    return await create_wf_index(
         "test-index",
         path,
         None,
@@ -359,7 +368,7 @@ async def index(workflow_data: WorkflowData, work_path: Path):
             },
         )
 
-    return await WFIndex.create(
+    return await create_wf_index(
         workflow_data.index.id,
         work_path / "indexes" / str(workflow_data.index.id) / "index.sqlite",
         None,
@@ -466,7 +475,7 @@ def make_redundant_index_otu() -> dict:
 
 @pytest.fixture()
 async def redundant_index(workflow_data: WorkflowData, tmp_path: Path) -> WFIndex:
-    return await WFIndex.create(
+    return await create_wf_index(
         workflow_data.index.id,
         tmp_path / "redundant-index.sqlite",
         None,
@@ -616,7 +625,7 @@ async def test_collapse_reference_index_allows_isolates_missing_schema_segments(
         for sequence in default_isolate["sequences"]
         if sequence["segment"] == "b"
     ]
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -708,7 +717,7 @@ async def test_collapse_reference_index_allows_unsegmented_isolates(
         ],
     )
 
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -763,7 +772,7 @@ async def test_collapse_reference_index_rejects_multiple_sequences_for_unsegment
         ],
     )
 
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -812,7 +821,7 @@ async def test_collapse_reference_index_preserves_single_unsegmented_isolate(
         ],
     )
     run_subprocess = mocker.AsyncMock()
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -862,7 +871,7 @@ async def test_collapse_reference_index_preserves_single_schema_isolate_without_
         ],
     )
     run_subprocess = mocker.AsyncMock()
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -919,7 +928,7 @@ async def test_collapse_reference_index_skips_invalid_schema_segment_names(
         ],
     )
     run_subprocess = mocker.AsyncMock()
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -1004,7 +1013,7 @@ async def test_collapse_reference_index_rejects_duplicate_isolate_segments(
             ),
         ],
     )
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -1053,7 +1062,7 @@ async def test_collapse_reference_index_rejects_unknown_isolate_segments(
             ),
         ],
     )
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -1114,7 +1123,7 @@ async def test_collapse_reference_index_handles_mixed_otu_outcomes(
             ),
         ],
     )
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -1155,7 +1164,7 @@ async def test_collapse_reference_index_propagates_subprocess_failures(
     mocker,
     tmp_path: Path,
 ):
-    source_index = await WFIndex.create(
+    source_index = await create_wf_index(
         "test-index",
         tmp_path / "source.sqlite",
         None,
@@ -1690,6 +1699,13 @@ async def test_pathoscope(
 
     # Snapshot test for the hits structure
     assert hits == snapshot
+    for hit in hits:
+        if hit["id"].startswith("13TF149_Reovirus"):
+            assert hit["otu"] == {"id": "reo", "version": 5}
+        elif hit["id"] in {"JQ080272", "KX109927"}:
+            assert hit["otu"] == {"id": "baz", "version": 6}
+        else:
+            assert hit["otu"] == {"id": "foobar", "version": 10}
 
     report: dict[str, list] = {}
 
@@ -1706,6 +1722,51 @@ async def test_pathoscope(
             report[split[0]] = [float(f"{float(n):.5g}") for n in split[1:]]
 
     assert report == snapshot
+
+
+async def test_build_isolate_index_resolves_candidate_sequences_to_otus(
+    collapsed_reference_path: Path,
+    index: WFIndex,
+    isolate_index_path: Path,
+    mocker,
+    tmp_path: Path,
+):
+    await create_test_index(collapsed_reference_path)
+    isolate_fasta_path = tmp_path / "isolates.fa"
+    run_subprocess = mocker.AsyncMock()
+    intermediate = SimpleNamespace(
+        candidate_sequence_ids={"default-a", "non-default", "non-default-only"},
+    )
+
+    await build_isolate_index(
+        collapsed_reference_path,
+        index,
+        intermediate,
+        isolate_fasta_path,
+        isolate_index_path,
+        run_subprocess,
+        2,
+    )
+
+    assert isolate_fasta_path.read_text().splitlines() == [
+        ">default-a",
+        "ACGT",
+        ">default-b",
+        "TTA",
+        ">non-default",
+        "GGGG",
+        ">non-default-only",
+        "CCCC",
+    ]
+    run_subprocess.assert_awaited_once_with(
+        [
+            "bowtie2-build",
+            "--threads",
+            "2",
+            str(isolate_fasta_path),
+            str(isolate_index_path),
+        ],
+    )
 
 
 async def test_build_isolate_index_no_candidates(

--- a/uv.lock
+++ b/uv.lock
@@ -106,6 +106,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.5"
 source = { registry = "https://pypi.org/simple" }
@@ -299,11 +308,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -1111,11 +1120,12 @@ wheels = [
 [[package]]
 name = "virtool"
 version = "0.0.0"
-source = { git = "https://github.com/virtool/virtool?tag=41.10.0#1298c1e1011521d7658140a25c6e18738f3c4a94" }
+source = { git = "https://github.com/virtool/virtool?tag=41.15.0#45a7c0176efedfab16fd0a1b4765539533939a5e" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp", extra = ["speedups"] },
     { name = "aiohttp-pydantic" },
+    { name = "aiosqlite" },
     { name = "alembic", extra = ["tz"] },
     { name = "arrow" },
     { name = "asyncpg" },
@@ -1174,7 +1184,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=41.10.0" }]
+requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=41.15.0" }]
 
 [package.metadata.requires-dev]
 dev = [

--- a/workflow.py
+++ b/workflow.py
@@ -221,10 +221,10 @@ async def build_isolate_index(
         return
 
     collapsed_index = WFIndex.load(index.id, collapsed_reference_path)
-    otu_refs = await collapsed_index.get_otu_refs_by_sequence_ids(
+    otu_summaries = await collapsed_index.get_otu_summaries_by_sequence_ids(
         intermediate.candidate_sequence_ids,
     )
-    otu_ids = {otu_ref["id"] for otu_ref in otu_refs.values()}
+    otu_ids = {summary["id"] for summary in otu_summaries.values()}
 
     await collapsed_index.write_fasta(
         isolate_fasta_path,
@@ -445,15 +445,18 @@ async def reassignment(
     logger.info("preparing hits")
 
     hits = []
-    otu_refs = await index.get_otu_refs_by_sequence_ids(report)
+    otu_summaries = await index.get_otu_summaries_by_sequence_ids(report)
 
     for sequence_id, hit in report.items():
-        otu_ref = otu_refs[sequence_id]
+        otu_summary = otu_summaries[sequence_id]
 
         hit["id"] = sequence_id
 
         # Attach "otu" (id, version) to the hit.
-        hit["otu"] = {"id": otu_ref["id"], "version": otu_ref["version"]}
+        hit["otu"] = {
+            "id": otu_summary["id"],
+            "version": otu_summary["version"],
+        }
 
         # Get the coverage for the sequence.
         hit_coverage = pathoscope_results.coverage[sequence_id]


### PR DESCRIPTION
## Summary

- pin Virtool 41.15.0 and regenerate the dependency lockfile
- adapt OTU summary lookups and SQLite reference creation to the new interfaces
- preserve candidate isolate indexing and reassignment metadata with focused coverage

## Verification

- mise run test: 33 Rust tests and 41 Python tests passed
- Ruff formatting and lint checks passed

Linear: VIR-2936