### PR TITLE
feat(deps): update virtool to 41.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ features = ["pyo3/extension-module"]
 asyncio_mode = "auto"
 
 [tool.uv.sources]
-virtool = { git = "https://github.com/virtool/virtool", tag = "41.16.0" }
+virtool = { git = "https://github.com/virtool/virtool", tag = "41.20.0" }
 
 [build-system]
 requires = ["maturin>=1.14.1,<2.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1120,7 +1120,7 @@ wheels = [
 [[package]]
 name = "virtool"
 version = "0.0.0"
-source = { git = "https://github.com/virtool/virtool?tag=41.16.0#eb3367db9fcb23cace41db6d42fe0ecc3c75d156" }
+source = { git = "https://github.com/virtool/virtool?tag=41.20.0#a870e26df3b21b2765a19d31572b6f165dda63a5" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp", extra = ["speedups"] },
@@ -1184,7 +1184,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=41.16.0" }]
+requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=41.20.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- update Virtool from 41.16.0 to 41.20.0
- regenerate the uv lockfile with the new resolved Git revision

## Validation

- mise run test: 33 Rust and 41 Python tests passed
- uv lock --check passed